### PR TITLE
extend endpoints with token

### DIFF
--- a/app/src/main/java/com/greenfox/fuchsit/zerdareader/activity/FeedFragment.java
+++ b/app/src/main/java/com/greenfox/fuchsit/zerdareader/activity/FeedFragment.java
@@ -69,7 +69,7 @@ public class FeedFragment extends ListFragment {
         Call<ArrayList<NewsItem>> call;
 
         if(tabNumber == 1) {
-            call = apiService.getNewsItems();
+            call = apiService.getNewsItems(sharedPreferences.getString("token", "default"));
         } else {
             call = apiService.getFavouriteNewsItems(sharedPreferences.getString("token", "default"));
         }

--- a/app/src/main/java/com/greenfox/fuchsit/zerdareader/activity/FeedFragment.java
+++ b/app/src/main/java/com/greenfox/fuchsit/zerdareader/activity/FeedFragment.java
@@ -94,7 +94,7 @@ public class FeedFragment extends ListFragment {
 
         NewsItem item = (NewsItem) feed.getItemAtPosition(position);
         updateRequest = new UpdateRequest(item.getId(), 1);
-        apiService.updateOpened(item.getId(), updateRequest);
+        apiService.updateOpened(item.getId(), updateRequest, sharedPreferences.getString("token", "default"));
 
         Intent i = new Intent(getActivity(), DetailedPageActivity.class);
         i.putExtra("newsItem", item);

--- a/app/src/main/java/com/greenfox/fuchsit/zerdareader/activity/FeedFragment.java
+++ b/app/src/main/java/com/greenfox/fuchsit/zerdareader/activity/FeedFragment.java
@@ -1,7 +1,9 @@
 package com.greenfox.fuchsit.zerdareader.activity;
 
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
 
 import android.support.v4.app.ListFragment;
@@ -39,6 +41,7 @@ public class FeedFragment extends ListFragment {
     ReaderApiInterface apiService;
 
     UpdateRequest updateRequest;
+    SharedPreferences sharedPreferences;
 
     @Nullable
     @Override
@@ -52,6 +55,7 @@ public class FeedFragment extends ListFragment {
         feed.setAdapter(adapter);
 
         DaggerMockServerComponent.builder().build().inject(this);
+        sharedPreferences = PreferenceManager.getDefaultSharedPreferences(getContext());
 
         tabNumber = getArguments().getInt("tabNumber", 1);
 
@@ -67,7 +71,7 @@ public class FeedFragment extends ListFragment {
         if(tabNumber == 1) {
             call = apiService.getNewsItems();
         } else {
-            call = apiService.getFavouriteNewsItems();
+            call = apiService.getFavouriteNewsItems(sharedPreferences.getString("token", "default"));
         }
 
 

--- a/app/src/main/java/com/greenfox/fuchsit/zerdareader/rest/ReaderApiInterface.java
+++ b/app/src/main/java/com/greenfox/fuchsit/zerdareader/rest/ReaderApiInterface.java
@@ -12,6 +12,7 @@ import retrofit2.http.GET;
 import retrofit2.http.POST;
 import retrofit2.http.PUT;
 import retrofit2.http.Path;
+import retrofit2.http.Query;
 
 /**
  * Created by Zsuzska on 2017. 01. 19..
@@ -20,7 +21,7 @@ import retrofit2.http.Path;
 public interface ReaderApiInterface {
 
     @GET("/favorites")
-    Call<ArrayList<NewsItem>> getFavouriteNewsItems();
+    Call<ArrayList<NewsItem>> getFavouriteNewsItems(@Query("token") String token);
 
     @GET("/feed")
     Call<ArrayList<NewsItem>> getNewsItems();

--- a/app/src/main/java/com/greenfox/fuchsit/zerdareader/rest/ReaderApiInterface.java
+++ b/app/src/main/java/com/greenfox/fuchsit/zerdareader/rest/ReaderApiInterface.java
@@ -24,7 +24,7 @@ public interface ReaderApiInterface {
     Call<ArrayList<NewsItem>> getFavouriteNewsItems(@Query("token") String token);
 
     @GET("/feed")
-    Call<ArrayList<NewsItem>> getNewsItems();
+    Call<ArrayList<NewsItem>> getNewsItems(@Query("token") String token);
 
     @POST("user/login")
     Call<UserResponse> loginUser(LoginRequest loginRequest);

--- a/app/src/main/java/com/greenfox/fuchsit/zerdareader/rest/ReaderApiInterface.java
+++ b/app/src/main/java/com/greenfox/fuchsit/zerdareader/rest/ReaderApiInterface.java
@@ -30,7 +30,7 @@ public interface ReaderApiInterface {
     Call<UserResponse> loginUser(LoginRequest loginRequest);
 
     @PUT("/feed/{item_id}")
-    void updateOpened(@Path("item_id") long id, UpdateRequest updateRequest);
+    void updateOpened(@Path("item_id") long id, UpdateRequest updateRequest, @Query("token") String token);
 
     @POST("user/signup")
     Call<UserResponse> signUpUser(LoginRequest loginRequest);

--- a/app/src/main/java/com/greenfox/fuchsit/zerdareader/server/MockServer.java
+++ b/app/src/main/java/com/greenfox/fuchsit/zerdareader/server/MockServer.java
@@ -27,7 +27,7 @@ import retrofit2.http.Path;
 
 public class MockServer implements ReaderApiInterface {
     @Override
-    public Call<ArrayList<NewsItem>> getFavouriteNewsItems() {
+    public Call<ArrayList<NewsItem>> getFavouriteNewsItems(String token) {
         return new MockCall<ArrayList<NewsItem>>() {
             @Override
             public void enqueue(Callback<ArrayList<NewsItem>> callback) {
@@ -45,7 +45,7 @@ public class MockServer implements ReaderApiInterface {
     }
 
     @Override
-    public MockCall<ArrayList<NewsItem>> getNewsItems() {
+    public MockCall<ArrayList<NewsItem>> getNewsItems(String token) {
         return new MockCall<ArrayList<NewsItem>>() {
             @Override
             public void enqueue(Callback<ArrayList<NewsItem>> callback) {
@@ -74,8 +74,7 @@ public class MockServer implements ReaderApiInterface {
     }
 
     @Override
-
-    public void updateOpened(@Path("item_id") long id, UpdateRequest updateRequest) {
+    public void updateOpened(long id, UpdateRequest updateRequest, String token) {
     }
 
     public MockCall<UserResponse> signUpUser(final LoginRequest loginRequest) {


### PR DESCRIPTION
token is passed as @Query in all endpoints in ReaderApiInterface where needed (exception: login and signup)